### PR TITLE
Исправление неправильного метода HTTP (GET -> POST)

### DIFF
--- a/pochta/api/documents.py
+++ b/pochta/api/documents.py
@@ -193,7 +193,7 @@ class Documents:
         """
         url = f'/1.0/batch/{batch_name}/checkin'
 
-        res = self._client.request(HTTPMethod.GET, url)
+        res = self._client.request(HTTPMethod.POST, url)
         return res.json()
 
     def create_comp_check_form(self, batch_name: str) -> Response:


### PR DESCRIPTION
Исправление неправильного метода HTTP при запросе подготовки электронной формы Ф103 (GET -> POST) в соответствии с документацией https://otpravka.pochta.ru/specification#/documents-checkin